### PR TITLE
API, Core: Make ScanReport and ScanReporter generic

### DIFF
--- a/api/src/main/java/org/apache/iceberg/metrics/LoggingMetricsReporter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/LoggingMetricsReporter.java
@@ -18,20 +18,19 @@
  */
 package org.apache.iceberg.metrics;
 
-import org.apache.iceberg.metrics.ScanReport.ScanMetrics;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * This interface defines the basic API for a Table Scan Reporter that can be used to report
- * different metrics after a Table scan is done.
+ * A default {@link MetricsReporter} implementation that logs the {@link ScanReport} to the log file.
  */
-@FunctionalInterface
-public interface ScanReporter {
+public class LoggingMetricsReporter implements MetricsReporter {
+  private static final Logger LOG = LoggerFactory.getLogger(LoggingMetricsReporter.class);
 
-  /**
-   * Indicates that a Scan is done by reporting a {@link ScanReport}. A {@link ScanReport} is
-   * usually directly derived from a {@link ScanMetrics} instance.
-   *
-   * @param scanReport The {@link ScanReport} to report.
-   */
-  void reportScan(ScanReport scanReport);
+  @Override
+  public void report(MetricsReport report) {
+    Preconditions.checkArgument(null != report, "Invalid scan report: null");
+    LOG.info("Completed scan planning: {}", report);
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/metrics/MetricsReport.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricsReport.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.metrics;
+
+public interface MetricsReport {
+}

--- a/api/src/main/java/org/apache/iceberg/metrics/MetricsReporter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricsReporter.java
@@ -18,19 +18,17 @@
  */
 package org.apache.iceberg.metrics;
 
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
- * A default {@link ScanReporter} implementation that logs the {@link ScanReport} to the log file.
+ * This interface defines the basic API for reporting metrics for operations to a Table.
  */
-public class LoggingScanReporter implements ScanReporter {
-  private static final Logger LOG = LoggerFactory.getLogger(LoggingScanReporter.class);
+@FunctionalInterface
+public interface MetricsReporter {
 
-  @Override
-  public void reportScan(ScanReport scanReport) {
-    Preconditions.checkArgument(null != scanReport, "Invalid scan report: null");
-    LOG.info("Completed scan planning: {}", scanReport);
-  }
+  /**
+   * Indicates that a operation is done by reporting a {@link MetricsReport}. A {@link MetricsReport} is
+   * usually directly derived from a {@link MetricsReport} instance.
+   *
+   * @param report The {@link MetricsReport} to report.
+   */
+  void report(MetricsReport report);
 }

--- a/api/src/main/java/org/apache/iceberg/metrics/ScanReport.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/ScanReport.java
@@ -29,7 +29,7 @@ import org.immutables.value.Value;
 
 /** A Table Scan report that contains all relevant information from a Table Scan. */
 @Value.Immutable
-public interface ScanReport {
+public interface ScanReport extends MetricsReport {
 
   String tableName();
 

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -24,8 +24,8 @@ import java.util.Map;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
-import org.apache.iceberg.metrics.LoggingScanReporter;
-import org.apache.iceberg.metrics.ScanReporter;
+import org.apache.iceberg.metrics.LoggingMetricsReporter;
+import org.apache.iceberg.metrics.MetricsReporter;
 
 /**
  * Base {@link Table} implementation.
@@ -39,18 +39,18 @@ import org.apache.iceberg.metrics.ScanReporter;
 public class BaseTable implements Table, HasTableOperations, Serializable {
   private final TableOperations ops;
   private final String name;
-  private final ScanReporter scanReporter;
+  private final MetricsReporter reporter;
 
   public BaseTable(TableOperations ops, String name) {
     this.ops = ops;
     this.name = name;
-    this.scanReporter = new LoggingScanReporter();
+    this.reporter = new LoggingMetricsReporter();
   }
 
-  public BaseTable(TableOperations ops, String name, ScanReporter scanReporter) {
+  public BaseTable(TableOperations ops, String name, MetricsReporter reporter) {
     this.ops = ops;
     this.name = name;
-    this.scanReporter = scanReporter;
+    this.reporter = reporter;
   }
 
   @Override
@@ -70,13 +70,13 @@ public class BaseTable implements Table, HasTableOperations, Serializable {
 
   @Override
   public TableScan newScan() {
-    return new DataTableScan(ops, this, schema(), new TableScanContext().reportWith(scanReporter));
+    return new DataTableScan(ops, this, schema(), new TableScanContext().reportWith(reporter));
   }
 
   @Override
   public IncrementalAppendScan newIncrementalAppendScan() {
     return new BaseIncrementalAppendScan(
-        ops, this, schema(), new TableScanContext().reportWith(scanReporter));
+        ops, this, schema(), new TableScanContext().reportWith(reporter));
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -130,7 +130,7 @@ abstract class BaseTableScan extends BaseScan<TableScan, FileScanTask, CombinedS
                     .filter(ExpressionUtil.sanitize(filter()))
                     .scanMetrics(ScanMetricsResult.fromScanMetrics(scanMetrics()))
                     .build();
-            context().scanReporter().reportScan(scanReport);
+            context().scanReporter().report(scanReport);
           });
     } else {
       LOG.info("Scanning empty table {}", table());

--- a/core/src/main/java/org/apache/iceberg/TableScanContext.java
+++ b/core/src/main/java/org/apache/iceberg/TableScanContext.java
@@ -24,8 +24,8 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
-import org.apache.iceberg.metrics.LoggingScanReporter;
-import org.apache.iceberg.metrics.ScanReporter;
+import org.apache.iceberg.metrics.LoggingMetricsReporter;
+import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.ThreadPools;
@@ -44,7 +44,7 @@ final class TableScanContext {
   private final Long toSnapshotId;
   private final ExecutorService planExecutor;
   private final boolean fromSnapshotInclusive;
-  private final ScanReporter scanReporter;
+  private final MetricsReporter reporter;
 
   TableScanContext() {
     this.snapshotId = null;
@@ -59,7 +59,7 @@ final class TableScanContext {
     this.toSnapshotId = null;
     this.planExecutor = null;
     this.fromSnapshotInclusive = false;
-    this.scanReporter = new LoggingScanReporter();
+    this.reporter = new LoggingMetricsReporter();
   }
 
   private TableScanContext(
@@ -75,7 +75,7 @@ final class TableScanContext {
       Long toSnapshotId,
       ExecutorService planExecutor,
       boolean fromSnapshotInclusive,
-      ScanReporter scanReporter) {
+      MetricsReporter reporter) {
     this.snapshotId = snapshotId;
     this.rowFilter = rowFilter;
     this.ignoreResiduals = ignoreResiduals;
@@ -88,7 +88,7 @@ final class TableScanContext {
     this.toSnapshotId = toSnapshotId;
     this.planExecutor = planExecutor;
     this.fromSnapshotInclusive = fromSnapshotInclusive;
-    this.scanReporter = scanReporter;
+    this.reporter = reporter;
   }
 
   Long snapshotId() {
@@ -109,7 +109,7 @@ final class TableScanContext {
         toSnapshotId,
         planExecutor,
         fromSnapshotInclusive,
-        scanReporter);
+        reporter);
   }
 
   Expression rowFilter() {
@@ -130,7 +130,7 @@ final class TableScanContext {
         toSnapshotId,
         planExecutor,
         fromSnapshotInclusive,
-        scanReporter);
+        reporter);
   }
 
   boolean ignoreResiduals() {
@@ -151,7 +151,7 @@ final class TableScanContext {
         toSnapshotId,
         planExecutor,
         fromSnapshotInclusive,
-        scanReporter);
+        reporter);
   }
 
   boolean caseSensitive() {
@@ -172,7 +172,7 @@ final class TableScanContext {
         toSnapshotId,
         planExecutor,
         fromSnapshotInclusive,
-        scanReporter);
+        reporter);
   }
 
   boolean returnColumnStats() {
@@ -193,7 +193,7 @@ final class TableScanContext {
         toSnapshotId,
         planExecutor,
         fromSnapshotInclusive,
-        scanReporter);
+        reporter);
   }
 
   Collection<String> selectedColumns() {
@@ -216,7 +216,7 @@ final class TableScanContext {
         toSnapshotId,
         planExecutor,
         fromSnapshotInclusive,
-        scanReporter);
+        reporter);
   }
 
   Schema projectedSchema() {
@@ -239,7 +239,7 @@ final class TableScanContext {
         toSnapshotId,
         planExecutor,
         fromSnapshotInclusive,
-        scanReporter);
+        reporter);
   }
 
   Map<String, String> options() {
@@ -263,7 +263,7 @@ final class TableScanContext {
         toSnapshotId,
         planExecutor,
         fromSnapshotInclusive,
-        scanReporter);
+        reporter);
   }
 
   Long fromSnapshotId() {
@@ -284,7 +284,7 @@ final class TableScanContext {
         toSnapshotId,
         planExecutor,
         false,
-        scanReporter);
+        reporter);
   }
 
   TableScanContext fromSnapshotIdInclusive(long id) {
@@ -301,7 +301,7 @@ final class TableScanContext {
         toSnapshotId,
         planExecutor,
         true,
-        scanReporter);
+        reporter);
   }
 
   boolean fromSnapshotInclusive() {
@@ -326,7 +326,7 @@ final class TableScanContext {
         id,
         planExecutor,
         fromSnapshotInclusive,
-        scanReporter);
+        reporter);
   }
 
   ExecutorService planExecutor() {
@@ -351,14 +351,14 @@ final class TableScanContext {
         toSnapshotId,
         executor,
         fromSnapshotInclusive,
-        scanReporter);
+        reporter);
   }
 
-  ScanReporter scanReporter() {
-    return scanReporter;
+  MetricsReporter scanReporter() {
+    return reporter;
   }
 
-  TableScanContext reportWith(ScanReporter reporter) {
+  TableScanContext reportWith(MetricsReporter reporter) {
     return new TableScanContext(
         snapshotId,
         rowFilter,

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -42,8 +42,8 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.TableIdentifierParser;
 import org.apache.iceberg.rest.auth.OAuth2Util;
-import org.apache.iceberg.rest.requests.SendMetricsRequest;
-import org.apache.iceberg.rest.requests.SendMetricsRequestParser;
+import org.apache.iceberg.rest.requests.ReportMetricsRequest;
+import org.apache.iceberg.rest.requests.ReportMetricsRequestParser;
 import org.apache.iceberg.rest.requests.UpdateRequirementParser;
 import org.apache.iceberg.rest.requests.UpdateTableRequest.UpdateRequirement;
 import org.apache.iceberg.rest.responses.ErrorResponse;
@@ -78,8 +78,8 @@ public class RESTSerializers {
         .addDeserializer(UpdateRequirement.class, new UpdateRequirementDeserializer())
         .addSerializer(OAuthTokenResponse.class, new OAuthTokenResponseSerializer())
         .addDeserializer(OAuthTokenResponse.class, new OAuthTokenResponseDeserializer())
-        .addSerializer(SendMetricsRequest.class, new SendMetricsRequestSerializer())
-        .addDeserializer(SendMetricsRequest.class, new SendMetricsRequestDeserializer());
+        .addSerializer(ReportMetricsRequest.class, new SendMetricsRequestSerializer())
+        .addDeserializer(ReportMetricsRequest.class, new SendMetricsRequestDeserializer());
     mapper.registerModule(module);
   }
 
@@ -259,21 +259,21 @@ public class RESTSerializers {
     }
   }
 
-  public static class SendMetricsRequestSerializer extends JsonSerializer<SendMetricsRequest> {
+  public static class SendMetricsRequestSerializer extends JsonSerializer<ReportMetricsRequest> {
     @Override
     public void serialize(
-        SendMetricsRequest request, JsonGenerator gen, SerializerProvider serializers)
+        ReportMetricsRequest request, JsonGenerator gen, SerializerProvider serializers)
         throws IOException {
-      SendMetricsRequestParser.toJson(request, gen);
+      ReportMetricsRequestParser.toJson(request, gen);
     }
   }
 
-  public static class SendMetricsRequestDeserializer extends JsonDeserializer<SendMetricsRequest> {
+  public static class SendMetricsRequestDeserializer extends JsonDeserializer<ReportMetricsRequest> {
     @Override
-    public SendMetricsRequest deserialize(JsonParser p, DeserializationContext context)
+    public ReportMetricsRequest deserialize(JsonParser p, DeserializationContext context)
         throws IOException {
       JsonNode jsonNode = p.getCodec().readTree(p);
-      return SendMetricsRequestParser.fromJson(jsonNode);
+      return ReportMetricsRequestParser.fromJson(jsonNode);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -56,9 +56,9 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.ResolvingFileIO;
-import org.apache.iceberg.metrics.LoggingScanReporter;
-import org.apache.iceberg.metrics.ScanReport;
-import org.apache.iceberg.metrics.ScanReporter;
+import org.apache.iceberg.metrics.LoggingMetricsReporter;
+import org.apache.iceberg.metrics.MetricsReport;
+import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -68,7 +68,7 @@ import org.apache.iceberg.rest.auth.OAuth2Util.AuthSession;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
-import org.apache.iceberg.rest.requests.SendMetricsRequest;
+import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
@@ -106,7 +106,7 @@ public class RESTSessionCatalog extends BaseSessionCatalog
   private ResourcePaths paths = null;
   private Object conf = null;
   private FileIO io = null;
-  private ScanReporter scanReporter = null;
+  private MetricsReporter reporter = null;
 
   // a lazy thread pool for token refresh
   private volatile ScheduledExecutorService refreshExecutor = null;
@@ -176,7 +176,7 @@ public class RESTSessionCatalog extends BaseSessionCatalog
     this.io =
         CatalogUtil.loadFileIO(
             ioImpl != null ? ioImpl : ResolvingFileIO.class.getName(), mergedProps, conf);
-    this.scanReporter = new LoggingScanReporter();
+    this.reporter = new LoggingMetricsReporter();
 
     super.initialize(name, mergedProps);
   }
@@ -300,11 +300,11 @@ public class RESTSessionCatalog extends BaseSessionCatalog
   }
 
   private void reportScan(
-      TableIdentifier tableIdentifier, ScanReport report, Supplier<Map<String, String>> headers) {
-    scanReporter.reportScan(report);
+      TableIdentifier tableIdentifier, MetricsReport report, Supplier<Map<String, String>> headers) {
+    reporter.report(report);
     client.post(
         paths.metrics(tableIdentifier),
-        SendMetricsRequest.builder().fromScanReport(report).build(),
+        ReportMetricsRequest.builder().fromReport(report).build(),
         null,
         headers,
         ErrorHandlers.defaultErrorHandler());

--- a/core/src/main/java/org/apache/iceberg/rest/requests/ReportMetricsRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/ReportMetricsRequest.java
@@ -18,69 +18,69 @@
  */
 package org.apache.iceberg.rest.requests;
 
-import org.apache.iceberg.metrics.ScanReport;
+import org.apache.iceberg.metrics.MetricsReport;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.rest.RESTRequest;
 
-public class SendMetricsRequest implements RESTRequest {
+public class ReportMetricsRequest implements RESTRequest {
 
-  public enum MetricsType {
+  public enum ReportType {
     UNKNOWN,
     SCAN_REPORT
   }
 
-  private ScanReport scanReport;
-  private MetricsType metricsType;
+  private MetricsReport report;
+  private ReportType reportType;
 
   @SuppressWarnings("unused")
-  public SendMetricsRequest() {
+  public ReportMetricsRequest() {
     // Needed for Jackson Deserialization.
   }
 
-  private SendMetricsRequest(ScanReport scanReport) {
-    this.scanReport = scanReport;
-    metricsType = null != scanReport ? MetricsType.SCAN_REPORT : MetricsType.UNKNOWN;
+  private ReportMetricsRequest(MetricsReport report) {
+    this.report = report;
+    reportType = null != report ? ReportType.SCAN_REPORT : ReportType.UNKNOWN;
     validate();
   }
 
-  public ScanReport scanReport() {
-    return scanReport;
+  public MetricsReport report() {
+    return report;
   }
 
-  public MetricsType getMetricsType() {
-    return metricsType;
+  public ReportType reportType() {
+    return reportType;
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("scanReport", scanReport).toString();
+    return MoreObjects.toStringHelper(this).add("report", report).toString();
   }
 
   @Override
   public void validate() {
     // new metric types might be added here, so we need to make sure that exactly one is not-null
-    Preconditions.checkArgument(null != scanReport, "Invalid scan report: null");
+    Preconditions.checkArgument(null != report, "Invalid scan report: null");
   }
 
-  public static SendMetricsRequest.Builder builder() {
-    return new SendMetricsRequest.Builder();
+  public static ReportMetricsRequest.Builder builder() {
+    return new ReportMetricsRequest.Builder();
   }
 
   public static class Builder {
-    private ScanReport scanReport;
+    private MetricsReport report;
 
     private Builder() {}
 
-    public Builder fromScanReport(ScanReport newScanReport) {
-      this.scanReport = newScanReport;
+    public Builder fromReport(MetricsReport newReport) {
+      this.report = newReport;
       return this;
     }
 
-    public SendMetricsRequest build() {
+    public ReportMetricsRequest build() {
       // new metric types might be added here, so we need to make sure that exactly one is not-null
-      Preconditions.checkArgument(null != scanReport, "Invalid scan report: null");
-      return new SendMetricsRequest(scanReport);
+      Preconditions.checkArgument(null != report, "Invalid scan report: null");
+      return new ReportMetricsRequest(report);
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestScanPlanningAndReporting.java
+++ b/core/src/test/java/org/apache/iceberg/TestScanPlanningAndReporting.java
@@ -25,16 +25,17 @@ import java.time.Duration;
 import java.util.List;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.metrics.LoggingScanReporter;
+import org.apache.iceberg.metrics.LoggingMetricsReporter;
+import org.apache.iceberg.metrics.MetricsReport;
 import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.metrics.ScanReport.ScanMetricsResult;
-import org.apache.iceberg.metrics.ScanReporter;
+import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.Test;
 
 public class TestScanPlanningAndReporting extends TableTestBase {
 
-  private final TestScanReporter reporter = new TestScanReporter();
+  private final TestMetricsReporter reporter = new TestMetricsReporter();
 
   public TestScanPlanningAndReporting() {
     super(2);
@@ -57,7 +58,7 @@ public class TestScanPlanningAndReporting extends TableTestBase {
       fileScanTasks.forEach(task -> {});
     }
 
-    ScanReport scanReport = reporter.lastReport();
+    ScanReport scanReport = (ScanReport) reporter.lastReport();
     assertThat(scanReport).isNotNull();
 
     assertThat(scanReport.tableName()).isEqualTo(tableName);
@@ -79,7 +80,7 @@ public class TestScanPlanningAndReporting extends TableTestBase {
       fileScanTasks.forEach(task -> {});
     }
 
-    scanReport = reporter.lastReport();
+    scanReport = (ScanReport) reporter.lastReport();
     result = scanReport.scanMetrics();
     assertThat(scanReport).isNotNull();
     assertThat(scanReport.tableName()).isEqualTo(tableName);
@@ -115,7 +116,7 @@ public class TestScanPlanningAndReporting extends TableTestBase {
       fileScanTasks.forEach(task -> {});
     }
 
-    ScanReport scanReport = reporter.lastReport();
+    ScanReport scanReport = (ScanReport) reporter.lastReport();
     assertThat(scanReport).isNotNull();
     assertThat(scanReport.tableName()).isEqualTo("scan-planning-with-deletes");
     assertThat(scanReport.snapshotId()).isEqualTo(2L);
@@ -146,7 +147,7 @@ public class TestScanPlanningAndReporting extends TableTestBase {
       fileScanTasks.forEach(task -> {});
     }
 
-    ScanReport scanReport = reporter.lastReport();
+    ScanReport scanReport = (ScanReport) reporter.lastReport();
     assertThat(scanReport).isNotNull();
     assertThat(scanReport.tableName()).isEqualTo(tableName);
     assertThat(scanReport.snapshotId()).isEqualTo(2L);
@@ -179,7 +180,7 @@ public class TestScanPlanningAndReporting extends TableTestBase {
       fileScanTasks.forEach(task -> {});
     }
 
-    ScanReport scanReport = reporter.lastReport();
+    ScanReport scanReport = (ScanReport) reporter.lastReport();
     assertThat(scanReport).isNotNull();
     assertThat(scanReport.tableName()).isEqualTo(tableName);
     assertThat(scanReport.snapshotId()).isEqualTo(2L);
@@ -197,18 +198,18 @@ public class TestScanPlanningAndReporting extends TableTestBase {
     assertThat(result.totalDeleteFileSizeInBytes().value()).isEqualTo(10L);
   }
 
-  private static class TestScanReporter implements ScanReporter {
-    private final List<ScanReport> reports = Lists.newArrayList();
+  private static class TestMetricsReporter implements MetricsReporter {
+    private final List<MetricsReport> reports = Lists.newArrayList();
     // this is mainly so that we see scan reports being logged during tests
-    private final LoggingScanReporter delegate = new LoggingScanReporter();
+    private final LoggingMetricsReporter delegate = new LoggingMetricsReporter();
 
     @Override
-    public void reportScan(ScanReport scanReport) {
-      reports.add(scanReport);
-      delegate.reportScan(scanReport);
+    public void report(MetricsReport report) {
+      reports.add(report);
+      delegate.report(report);
     }
 
-    public ScanReport lastReport() {
+    public MetricsReport lastReport() {
       if (reports.isEmpty()) {
         return null;
       }

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -30,7 +30,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.metrics.ScanReporter;
+import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -79,7 +79,7 @@ public class TestTables {
       PartitionSpec spec,
       SortOrder sortOrder,
       int formatVersion,
-      ScanReporter scanReporter) {
+      MetricsReporter reporter) {
     TestTableOperations ops = new TestTableOperations(name, temp);
     if (ops.current() != null) {
       throw new AlreadyExistsException("Table %s already exists at location: %s", name, temp);
@@ -90,7 +90,7 @@ public class TestTables {
         newTableMetadata(
             schema, spec, sortOrder, temp.toString(), ImmutableMap.of(), formatVersion));
 
-    return new TestTable(ops, name, scanReporter);
+    return new TestTable(ops, name, reporter);
   }
 
   public static Transaction beginCreate(File temp, String name, Schema schema, PartitionSpec spec) {
@@ -180,8 +180,8 @@ public class TestTables {
       this.ops = ops;
     }
 
-    private TestTable(TestTableOperations ops, String name, ScanReporter scanReporter) {
-      super(ops, name, scanReporter);
+    private TestTable(TestTableOperations ops, String name, MetricsReporter reporter) {
+      super(ops, name, reporter);
       this.ops = ops;
     }
 

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -43,7 +43,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
-import org.apache.iceberg.rest.requests.SendMetricsRequest;
+import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ConfigResponse;
@@ -128,7 +128,7 @@ public class RESTCatalogAdapter implements RESTClient {
     SEND_METRICS(
         HTTPMethod.POST,
         "v1/namespaces/{namespace}/tables/{table}/metrics",
-        SendMetricsRequest.class,
+        ReportMetricsRequest.class,
         null);
 
     private final HTTPMethod method;
@@ -347,7 +347,7 @@ public class RESTCatalogAdapter implements RESTClient {
       case SEND_METRICS:
         {
           // nothing to do here other than checking that we're getting the correct request
-          castRequest(SendMetricsRequest.class, body);
+          castRequest(ReportMetricsRequest.class, body);
           return null;
         }
 


### PR DESCRIPTION
This introduces a generic MetricsReport interface that ScanReport extends, and makes the report infrastructure generic by migrating ScanReporter to be MetricsReporter and use a ReportMetricsRequest in for REST reporting.

This isn't complete. MetricsReport should probably expose metrics as a map so that we don't require a special parser for ScanMetricsResult, CommitMetricsResult, etc.

The main purpose of this PR is to demonstrate how we can update the report parser to use a single level, while still having specific metrics report classes, like ScanReport.