### PR TITLE
Update resolution to apply aliases and comments.

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -537,6 +537,62 @@ public class SparkCatalog extends BaseCatalog
   }
 
   @Override
+  public Identifier[] listViews(String... namespace) {
+    throw new UnsupportedOperationException(
+        "Listing views is not supported by catalog: " + catalogName);
+  }
+
+  @Override
+  public View loadView(Identifier ident) throws NoSuchViewException {
+    if (null != asViewCatalog) {
+      try {
+        org.apache.iceberg.view.View view = asViewCatalog.loadView(buildIdentifier(ident));
+        return new SparkView(catalogName, view);
+      } catch (org.apache.iceberg.exceptions.NoSuchViewException e) {
+        throw new NoSuchViewException(ident);
+      }
+    }
+
+    throw new NoSuchViewException(ident);
+  }
+
+  @Override
+  public View createView(
+      Identifier ident,
+      String sql,
+      String currentCatalog,
+      String[] currentNamespace,
+      StructType schema,
+      String[] queryColumnNames,
+      String[] columnAliases,
+      String[] columnComments,
+      Map<String, String> properties)
+      throws ViewAlreadyExistsException, NoSuchNamespaceException {
+    throw new UnsupportedOperationException(
+        "Creating a view is not supported by catalog: " + catalogName);
+  }
+
+  @Override
+  public View alterView(Identifier ident, ViewChange... changes)
+      throws NoSuchViewException, IllegalArgumentException {
+    throw new UnsupportedOperationException(
+        "Altering a view is not supported by catalog: " + catalogName);
+  }
+
+  @Override
+  public boolean dropView(Identifier ident) {
+    throw new UnsupportedOperationException(
+        "Dropping a view is not supported by catalog: " + catalogName);
+  }
+
+  @Override
+  public void renameView(Identifier fromIdentifier, Identifier toIdentifier)
+      throws NoSuchViewException, ViewAlreadyExistsException {
+    throw new UnsupportedOperationException(
+        "Renaming a view is not supported by catalog: " + catalogName);
+  }
+
+  @Override
   public final void initialize(String name, CaseInsensitiveStringMap options) {
     this.cacheEnabled =
         PropertyUtil.propertyAsBoolean(
@@ -821,61 +877,5 @@ public class SparkCatalog extends BaseCatalog
   @Override
   public Catalog icebergCatalog() {
     return icebergCatalog;
-  }
-
-  @Override
-  public Identifier[] listViews(String... namespace) {
-    throw new UnsupportedOperationException(
-        "Listing views is not supported by catalog: " + catalogName);
-  }
-
-  @Override
-  public View loadView(Identifier ident) throws NoSuchViewException {
-    if (null != asViewCatalog) {
-      try {
-        org.apache.iceberg.view.View view = asViewCatalog.loadView(buildIdentifier(ident));
-        return new SparkView(catalogName, view);
-      } catch (org.apache.iceberg.exceptions.NoSuchViewException e) {
-        throw new NoSuchViewException(ident);
-      }
-    }
-
-    throw new NoSuchViewException(ident);
-  }
-
-  @Override
-  public View createView(
-      Identifier ident,
-      String sql,
-      String currentCatalog,
-      String[] currentNamespace,
-      StructType schema,
-      String[] queryColumnNames,
-      String[] columnAliases,
-      String[] columnComments,
-      Map<String, String> properties)
-      throws ViewAlreadyExistsException, NoSuchNamespaceException {
-    throw new UnsupportedOperationException(
-        "Creating a view is not supported by catalog: " + catalogName);
-  }
-
-  @Override
-  public View alterView(Identifier ident, ViewChange... changes)
-      throws NoSuchViewException, IllegalArgumentException {
-    throw new UnsupportedOperationException(
-        "Altering a view is not supported by catalog: " + catalogName);
-  }
-
-  @Override
-  public boolean dropView(Identifier ident) {
-    throw new UnsupportedOperationException(
-        "Dropping a view is not supported by catalog: " + catalogName);
-  }
-
-  @Override
-  public void renameView(Identifier fromIdentifier, Identifier toIdentifier)
-      throws NoSuchViewException, ViewAlreadyExistsException {
-    throw new UnsupportedOperationException(
-        "Renaming a view is not supported by catalog: " + catalogName);
   }
 }


### PR DESCRIPTION
This fixes a couple of questions from the review, https://github.com/apache/iceberg/pull/9340.

* Fixes temp view resolution
* Applies the expected schema if needed, resolving columns by position only
* Adds an Origin while parsing the view plan
* Uses `parseQuery` instead of `parsePlan` to ensure the view text is a query and not a command
* Relocates view methods in `SparkCatalog`
* Rewrites function names and adds tests
* Updates tests that were failing due to mismatched schemas
* Adds extra test case for a view referencing a conflicting name (both temp view and permanent view)